### PR TITLE
Bump to ghc 9.4.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,1 @@
-(import ./nix/pkgs.nix).nixpkgs.haskellPackages.nightfall
+(import ./nix/pkgs.nix).nightfall

--- a/src/Nightfall/MASM/Types.hs
+++ b/src/Nightfall/MASM/Types.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Nightfall.MASM.Types where
 


### PR DESCRIPTION
Besides the language changes, this should make HLS work properly outside of the main library: 
https://well-typed.com/blog/2023/03/cabal-multi-unit/#hls-support-for-multiple-home-units