### PR TITLE
Override cabal with newer version adding multi repl support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: *
+tests: True

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/nix/cabal-multi-repl.nix
+++ b/nix/cabal-multi-repl.nix
@@ -1,0 +1,28 @@
+let
+  nixpkgs-src = builtins.fetchTarball {
+    # https://github.com/haskell/cabal/pull/8726 on top of haskell-updates 23/03/23
+    url = "https://github.com/qrlex/nixpkgs/archive/c149517ad5d6761cf22515e1f84baabbbe1fb77b.tar.gz";
+    sha256 = "sha256:0jrzj4fkxnwhc3c6azq9178pn8nq3ns37y4k1v1pdm7hvrhrimkq";
+  };
+
+  config = {
+    packageOverrides = pkgs: with pkgs.haskell.lib; {
+      haskell = pkgs.haskell // {
+        packages = pkgs.haskell.packages // {
+          ghc96 = pkgs.haskell.packages.ghc96.override(old: {
+            overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: {})) (self: super: {
+              # newer ghc and/or cabal changes the value of `srcLocPackage` in
+              # https://github.com/sol/call-stack/blob/1d78c6320f986a2948b2076736b1678e53f862cf/test/Data/CallStackSpec.hs#L16
+              call-stack = dontCheck super.call-stack;
+            });
+          });
+        };
+      };
+    };
+  };
+
+  nixpkgs = import nixpkgs-src {inherit config; };
+
+in {
+  inherit (nixpkgs.haskell.packages.ghc96) cabal-install;
+}

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,7 +1,7 @@
 let
-  nixpkgsSrc = builtins.fetchTarball {
+  nixpkgs-src = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/0d1b9472176bb31fa1f9a7b86ccbb20c656e6792.tar.gz"; # haskell-updates 23/03/23
-    sha256 = "0j7y0s691xjs2146pkssz5wd3dc5qkvzx106m911anvzd08dbx9f";
+    sha256 = "sha256:0j7y0s691xjs2146pkssz5wd3dc5qkvzx106m911anvzd08dbx9f";
   };
 
   config = {
@@ -24,7 +24,7 @@ let
     };
   };
 
-  nixpkgs = import nixpkgsSrc { inherit config; };
+  nixpkgs = import nixpkgs-src { inherit config; };
 
   shell = nixpkgs.haskell.packages.ghc94.shellFor {
     strictDeps = true;
@@ -32,12 +32,12 @@ let
     withHoogle = true;
     nativeBuildInputs =
       let hask = with nixpkgs.haskell.packages.ghc94; [
-        cabal-install
+        (import ./cabal-multi-repl.nix).cabal-install
         ghcid
         (haskell-language-server.overrideAttrs(finalAttrs: previousAttrs: { propagatedBuildInputs = []; buildInputs = previousAttrs.propagatedBuildInputs; }))
       ];
       in with nixpkgs; hask ++ [
-        nixpkgs.zlib
+        zlib
       ];
   };
 in


### PR DESCRIPTION
This allows `cabal repl --enable-multi-repl all` to load both the library and executables/test-suites into the same ghci. It should also work for multiple local packages IIUC https://well-typed.com/blog/2023/03/cabal-multi-unit/#multiple-component-repl. 

This flag can be enabled by default in `cabal.project` but I kept it opt-in as it's still experimental. 
In particular, it doesn't support `:set` and other commands, possibly interfering with `.ghci` files, though `:seti` works.

As for `ghcid -c 'cabal repl --enable-multi-repl all'`, it works properly with ghc 9.6, but in 9.4 it's somewhat broken due to

```
ghci> :show modules 
Main             ( <path>/nightfall/test/Main.hs, interpreted )
panic! (the 'impossible' happened)
  GHC version 9.4.4:
	missing linkable

Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug
```

resulting in ghcid only picking up changes to other modules after `Main` is changed. 
I suppose `watch touch test/Main.hs` can somewhat act as a crutch.