### PR TITLE
Overhaul integral types

### DIFF
--- a/nightfall.cabal
+++ b/nightfall.cabal
@@ -22,25 +22,29 @@ common dev-flags
 library
     import:           warnings
     import:           dev-flags
-    exposed-modules:  Nightfall,
-                      Nightfall.MASM,
-                      Nightfall.MASM.Callgraph,
-                      Nightfall.MASM.Miden,
-                      Nightfall.MASM.Types,
-                      Nightfall.Lang.Types,
-                      Nightfall.Targets.Miden,
-                      Examples.Simple,
-                      Examples.Cond,
-                      Examples.Loops,
-                      Examples.Fun,
+    exposed-modules:
+                      Examples.Cond
+                      Examples.Fun
                       Examples.Inputs
-    other-modules:    Nightfall.Lang.Internal.Types,
+                      Examples.Loops
+                      Examples.Simple
+                      Nightfall
+                      Nightfall.Lang.Internal.Felt
+                      Nightfall.Lang.Internal.Types
+                      Nightfall.Lang.Types
+                      Nightfall.MASM
+                      Nightfall.MASM.Callgraph
+                      Nightfall.MASM.Integral
+                      Nightfall.MASM.Miden
+                      Nightfall.MASM.Types
+                      Nightfall.Targets.Miden
     -- other-extensions:
     build-depends:    base >=4.16 && <5
                     , containers
                     , directory
                     , dlist
                     , filepath
+                    , galois-field
                     , mtl
                     , process
                     , temporary

--- a/src/Examples/Fun.hs
+++ b/src/Examples/Fun.hs
@@ -53,7 +53,7 @@ collatzPrivStmts :: [Statement]
 collatzPrivStmts = [ comment "Compute the Collatz sequence, starting position taken from secret input"
                   , comment "It returns the length of the sequence"
                   , emptyLine
-                  , declareVarF "start" nextSecretF
+                  , declareVarF "start" nextSecret
                   , declareVarF "n" (varF "start")
                   , declareVarF "length" 1
                   , while (varF "n" `gt` 1) [ incVarF "length" 1

--- a/src/Examples/Inputs.hs
+++ b/src/Examples/Inputs.hs
@@ -15,8 +15,8 @@ simpleSecret secret = 10 * secret
 simpleSecretStmts :: [Statement]
 simpleSecretStmts = [ comment "Simple program that outputs 10x the secret input"
                     , emptyLine
-                    , ret . Just $ 10 * nextSecretF
+                    , ret . Just $ 10 * nextSecret
                     ]
 
 simpleSecretProg :: ZKProgram
-simpleSecretProg = mkZKProgram "simple secret" simpleSecretStmts [] "simple_secrets.inputs" 
+simpleSecretProg = mkZKProgram "simple secret" simpleSecretStmts [] "simple_secrets.inputs"

--- a/src/Nightfall/Lang/Internal/Felt.hs
+++ b/src/Nightfall/Lang/Internal/Felt.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Nightfall.Lang.Internal.Felt where
+
+import Data.Word (Word64)
+import Data.Coerce
+import GHC.Generics
+import Data.Typeable
+import qualified Data.Field.Galois as Galois
+import GHC.TypeNats
+import Data.Ratio
+
+{- Note [Handling on integral types]
+Without completely paranoic handling of integral types it is trivial to cause an overflow, which may
+easily result in a vulnerability. We therefore 'newtype'-wrap every integral type (including the
+type of field elements), specify its range (sometimes as right at the type level, sometimes as a
+comment) and discourage usage of functions that operate on the underlying representation by
+attaching the "unsafe" prefix to their name.
+
+Any wrapping is only considered safe when either any input is handled correctly or bounds are
+checked and 'Nothing' is returned if the provided value doesn't fit. Thus both throwing and implicit
+conversions between types of different cardinality are considered unsafe, although between the two
+unsafe options the former is highly preferable.
+
+Any unwrapping is only considered safe as long as the result is converted to 'Integer' before the
+unwrapping function returns, so that the user cannot accidentally cause an overflow using the
+result of the unwrapping function and subsequently "safely" embed that overflow back into the
+integral type.
+-}
+
+-- TODO: given that 'Felt' doesn't cover the entire 'Word64' anyway, should we simply use 'Natural'
+-- here? That would be more efficient, since 'Galois.Prime' is a wrapper around 'Natural' and we
+-- derive a lot of operations using that wrapper. We can't do better than 'Natural' performance-wise
+-- anyway, because we need to be able to handle, say, @(2 * Felt (maxBound :: Word64))@ somehow,
+-- i.e. an intermediate step can go well beyond 'Word64' before the modulo operation is executed and
+-- the result is back within 'Word64'.
+--
+-- Plus, having a 'Natural' here is simply safer as it doesn't pose any risk of causing an
+-- overflow. On the other hand there's still risk of underflow, but at least that causes an
+-- exception with 'Natural'. 'Integer' perhaps would be the safest and the slowest option. Although
+-- given Note [Handling on integral types] we should be able to afford the minor unsafety of
+-- 'Natural' here, since we're sufficiently paranoic when it comes to constructing and
+-- deconstructing 'Felt's.
+-- | The type of finite field that the Miden VM operates on.
+--
+-- Note that it's extremely unsafe to use the constructor directly since 'Word64' is prone to
+-- overflows, here's an example:
+--
+-- >>> let hundredOnes = replicate 100 '1'
+-- >>> Felt $ read hundredOnes
+-- Felt 8198552921648689607
+-- >>> toFelt $ read hundredOnes
+-- Felt 9806726161887342870
+--
+-- Plus, Miden's 'Felt' doesn't include the entire range of 'Word64', which is another reason why
+-- using the constructor directly is extremely unsafe.
+--
+-- Hence always use 'toFelt' (or, equivalently, 'fromInteger' or numeric syntax) unless you can
+-- prove that no overflow can happen (and even in that case perhaps still use 'toFelt'). Do not
+-- reexport the constructor from any other module.
+--
+-- Invariant:
+--
+-- > forall (i :: Felt). 0 <= i && i < feltOrder
+newtype Felt = Felt Word64
+    deriving (Eq, Ord, Show, Generic, Typeable)
+
+-- | The order (a.k.a. size) of the 'Felt' field.
+type FeltOrder = 2 ^ 64 - 2 ^ 32 + 1
+
+-- | Convert a 'Felt' element to the corresponding 'Galois.Prime' element. Useful for defining
+-- operations over 'Felt' that are already defined over 'Galois.Prime'.
+feltToPrime :: Felt -> Galois.Prime FeltOrder
+feltToPrime = coerce (fromIntegral :: Word64 -> Galois.Prime FeltOrder)
+{-# INLINE feltToPrime #-}
+
+-- | Convert a 'Galois.Prime' element to the corresponding 'Felt' element. Useful for defining
+-- operations over 'Felt' that are already defined over 'Galois.Prime'.
+primeToFelt :: Galois.Prime FeltOrder -> Felt
+primeToFelt = coerce (fromIntegral :: Galois.Prime FeltOrder -> Word64)
+{-# INLINE primeToFelt #-}
+
+instance Num Felt where
+    fromInteger = toFelt
+    {-# INLINE fromInteger #-}
+
+    i + j = primeToFelt $ feltToPrime i + feltToPrime j
+    {-# INLINE (+) #-}
+
+    i * j = primeToFelt $ feltToPrime i * feltToPrime j
+    {-# INLINE (*) #-}
+
+    i - j = primeToFelt $ feltToPrime i - feltToPrime j
+    {-# INLINE (-) #-}
+
+    abs = error "'abs' is not defined for 'Felt'"
+    signum = error "'signum' is not defined for 'Felt'"
+
+instance Fractional Felt where
+    i / j = primeToFelt $ feltToPrime i / feltToPrime j
+    {-# INLINE (/) #-}
+
+    fromRational r = fromInteger (numerator r) / fromInteger (denominator r)
+    {-# INLINE fromRational #-}
+
+-- | Convert a 'Felt' to the corresponding 'Integer'.
+unFelt :: Felt -> Integer
+unFelt = coerce (fromIntegral :: Word64 -> Integer)
+{-# INLINE unFelt #-}
+
+-- See Note [Handling on integral types].
+-- | Unwrap a 'Felt' to get the underlying 'Word64'. This is only unsafe in the sense that
+-- performing operations over the resulting 'Word64' may result in overflow and hence usage of
+-- 'unsafeUnFelt' is discouraged. Use 'unFelt' whenever possible instead.
+unsafeUnFelt :: Felt -> Word64
+unsafeUnFelt = coerce
+{-# INLINE unsafeUnFelt #-}
+
+-- | The order (a.k.a. size) of the 'Felt' field as a 'Word64'.
+feltOrder :: Word64
+feltOrder = fromIntegral . natVal $ Proxy @FeltOrder
+-- No point in inlining this definition, it would be neither efficient nor readable in the generated
+-- Core.
+{-# NOINLINE feltOrder #-}
+
+-- | The order (a.k.a. size) of the 'Felt' field as an 'Integer', provided for solely for the
+-- purpose of not recomputing the 'Integer' version of 'feltOrder'.
+feltOrderInteger :: Integer
+feltOrderInteger = fromIntegral feltOrder
+{-# NOINLINE feltOrderInteger #-}
+
+-- | Convert an 'Integer' of an arbitrary size to a 'Felt'.
+toFelt :: Integer -> Felt
+toFelt = primeToFelt . fromInteger
+{-# INLINE toFelt #-}

--- a/src/Nightfall/Lang/Internal/Types.hs
+++ b/src/Nightfall/Lang/Internal/Types.hs
@@ -1,9 +1,13 @@
-module Nightfall.Lang.Internal.Types where
+module Nightfall.Lang.Internal.Types
+    ( module Nightfall.Lang.Internal.Types
+    , Felt
+    , unFelt
+    , feltOrder
+    , feltOrderInteger
+    , toFelt
+    ) where
 
-import Data.Word ( Word64 )
-
--- | Field Element type
-type Felt = Word64
+import Nightfall.Lang.Internal.Felt
 
 type VarName = String
 
@@ -22,7 +26,7 @@ data BinOp =
     | Sub     -- ^ a - b
     | Mul     -- ^ a * b
     | Div     -- ^ a / b (integer division)
-    | IDiv32  -- ^ a `quot` b with a and b 32-bit integers
+    | IDiv32  -- ^ a `quot` b with a and b being 'Word32'
 
     -- Boolean operations
     | Equal      -- ^ a == b
@@ -35,7 +39,7 @@ data BinOp =
 -- | Expression, internal type, not exposed
 data Expr_ =
     -- | Literals
-      Lit Felt  -- ^ 309183, 2398713, whatever NOTE: we might want to use explicit types like W32, W64, etc.?
+      Lit Felt  -- ^ 309183, 2398713, whatever
     | Bo Bool   -- ^ true/false, 1/0
 
     | UnOp UnOp Expr_

--- a/src/Nightfall/MASM.hs
+++ b/src/Nightfall/MASM.hs
@@ -68,7 +68,7 @@ ppInstr (LocLoad n) = [ "loc_load." ++ show n ]
 
 ppInstr (AdvPush n) = [ "adv_push." ++ show n ]
 ppInstr (Push n) = [ "push." ++ show n ]
-ppInstr (Swap n) = [ "swap" ++ if n == 1 then "" else "." ++ show n ]
+ppInstr (Swap n) = [ "swap" ++ if unStackIndex n == 1 then "" else "." ++ show n ]
 ppInstr Drop = "drop"
 ppInstr CDrop = "cdrop"
 ppInstr (Dup n) = [ "dup." ++ show n ]

--- a/src/Nightfall/MASM/Integral.hs
+++ b/src/Nightfall/MASM/Integral.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Nightfall.MASM.Integral where
+
+import GHC.Bits (toIntegralSized)
+import Data.Word (Word8, Word32)
+import Data.Coerce
+import GHC.Generics
+import Data.Typeable
+import GHC.TypeNats
+
+-- | The type of indices into Miden's stack, each element is greater than or equal to @lower@ and
+-- less than or equal to @upper@.
+newtype StackIndex (lower :: Nat) (upper :: Nat) = StackIndex Word8
+    deriving (Eq, Ord, Show, Generic, Typeable)
+
+-- | Convert a 'StackIndex' to the corresponding 'Integer'.
+unStackIndex :: StackIndex lower upper -> Integer
+unStackIndex = coerce (toInteger :: Word8 -> Integer)
+
+-- See Note [Handling on integral types].
+-- | Unwrap a 'StackIndex' to get the underlying 'Word8'. This is only unsafe in the sense that
+-- performing operations over the resulting 'Word8' may result in overflow and hence usage of
+-- 'unsafeStackIndex' is discouraged. Use 'unStackIndex' whenever possible instead.
+unsafeStackIndex :: StackIndex lower upper -> Word8
+unsafeStackIndex = coerce
+
+-- | Convert an 'Integer' to the corresponding 'StackIndex'. Returns 'Nothing' if the integer
+-- doesn't fit into 'StackIndex'.
+toStackIndex ::
+      forall lower upper. (KnownNat lower, KnownNat upper)
+    => Integer -> Maybe (StackIndex lower upper)
+toStackIndex i
+    | lower <= i && i <= upper = Just . StackIndex $ fromInteger i
+    | otherwise                = Nothing
+    where
+        lower = toInteger . natVal $ Proxy @lower
+        upper = toInteger . natVal $ Proxy @upper
+
+-- See Note [Handling on integral types].
+-- | Convert an 'Integer' to the corresponding 'StackIndex'. Silently overflows if the integer
+-- doesn't fit into 'StackIndex'. Use 'toStackIndex' whenever possible instead.
+unsafeToStackIndex :: Integer -> StackIndex lower upper
+unsafeToStackIndex = coerce (fromInteger :: Integer -> Word8)
+
+-- | The type of indices in Miden's global memory (accessed via @mem_load@, @mem_store@ etc).
+newtype MemoryIndex = MemoryIndex Word32
+    deriving (Eq, Ord, Show, Generic, Typeable)
+
+-- | Convert a 'MemoryIndex' to the corresponding 'Integer'.
+unMemoryIndex :: MemoryIndex -> Integer
+unMemoryIndex = coerce (toInteger :: Word32 -> Integer)
+
+-- See Note [Handling on integral types].
+-- | Unwrap a 'MemoryIndex' to get the underlying 'Word32'. This is only unsafe in the sense that
+-- performing operations over the resulting 'Word32' may result in overflow and hence usage of
+-- 'unsafeMemoryIndex' is discouraged. Use 'unMemoryIndex' whenever possible instead.
+unsafeUnMemoryIndex :: MemoryIndex -> Word32
+unsafeUnMemoryIndex = coerce
+
+-- | Convert an 'Integer' to the corresponding 'MemoryIndex'. Returns 'Nothing' if the integer
+-- doesn't fit into 'MemoryIndex'.
+toMemoryIndex :: Integer -> Maybe MemoryIndex
+toMemoryIndex = coerce (toIntegralSized :: Integer -> Maybe Word32)
+
+-- See Note [Handling on integral types].
+-- | Convert an 'Integer' to the corresponding 'MemoryIndex'. Silently overflows if the integer
+-- doesn't fit into 'MemoryIndex'. Use 'toMemoryIndex' whenever possible instead.
+unsafeToMemoryIndex :: Integer -> MemoryIndex
+unsafeToMemoryIndex = coerce (fromInteger :: Integer -> Word32)

--- a/src/Nightfall/MASM/Miden.hs
+++ b/src/Nightfall/MASM/Miden.hs
@@ -25,7 +25,7 @@ runMiden :: KeepFile -> Module -> IO (Either String [Word32])
 runMiden keep m = withSystemTempFile "nightfall-testfile-XXX.masm" $ \fp hndl -> do
     hPutStrLn hndl (ppMASM m)
     hClose hndl
-    whenKeep keep $ \masmModSaveFp -> copyFile fp masmModSaveFp
+    _ <- whenKeep keep $ \masmModSaveFp -> copyFile fp masmModSaveFp
     (ex, midenout, midenerr) <- readProcessWithExitCode "miden" ["run", "--assembly", fp] ""
     case ex of
         ExitSuccess -> do

--- a/src/Nightfall/MASM/Types.hs
+++ b/src/Nightfall/MASM/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -7,7 +8,20 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Nightfall.MASM.Types where
+module Nightfall.MASM.Types
+    ( module Nightfall.MASM.Types
+    , StackIndex
+    , unStackIndex
+    , toStackIndex
+    , unsafeToStackIndex
+    , MemoryIndex
+    , unMemoryIndex
+    , toMemoryIndex
+    , unsafeToMemoryIndex
+    ) where
+
+import Nightfall.MASM.Integral
+import Nightfall.Lang.Types
 
 import Control.Monad.Writer.Strict
 import qualified Data.DList as DList
@@ -47,32 +61,32 @@ data Instruction
         elseBranch :: [Instruction]
       }
   | While [Instruction] -- while.true
-  | AdvPush Word32 -- adv_push.n
-  | Push Word32 -- push.n
-  | Swap Word32 -- swap[.i]
+  | AdvPush (StackIndex 1 16)  -- adv_push.n
+  | Push Felt -- push.n
+  | Swap (StackIndex 1 15) -- swap[.i]
   | Drop -- drop
   | CDrop -- cdrop
-  | Dup Word32 -- dup.n
-  | MoveUp Word32 -- movup.n
-  | MoveDown Word32 -- movdn.n
+  | Dup (StackIndex 0 15) -- dup.n
+  | MoveUp (StackIndex 2 15) -- movup.n
+  | MoveDown (StackIndex 2 15) -- movdn.n
   | TruncateStack -- exec.sys::truncate_stack
   | SDepth -- sdepth
-  | Eq (Maybe Word32) -- eq[.n]
-  | NEq (Maybe Word32) -- neq[.n]
+  | Eq (Maybe Felt) -- eq[.n]
+  | NEq (Maybe Felt) -- neq[.n]
   | Lt -- lt
   | Lte -- lte
   | Gt -- gt
   | Gte -- gte
   | Not -- not
   | IsOdd -- is_odd
-  | LocStore Word32 -- loc_store.i
-  | LocLoad Word32 -- loc_load.i
-  | MemLoad (Maybe Word32) -- mem_load[.i]
-  | MemStore (Maybe Word32) -- mem_store[.i]
-  | Add (Maybe Word32) -- add[.n]
-  | Sub (Maybe Word32) -- sub[.n]
-  | Mul (Maybe Word32) -- mul[.n]
-  | Div (Maybe Word32) -- div[.n]
+  | LocStore MemoryIndex -- loc_store.i
+  | LocLoad MemoryIndex -- loc_load.i
+  | MemLoad (Maybe MemoryIndex) -- mem_load[.i]
+  | MemStore (Maybe MemoryIndex) -- mem_store[.i]
+  | Add (Maybe Felt) -- add[.n]
+  | Sub (Maybe Felt) -- sub[.n]
+  | Mul (Maybe Felt) -- mul[.n]
+  | Div (Maybe Felt) -- div[.n]
   | Neg
   | IAdd -- u32checked_add
   | ISub -- "u32checked_sub"


### PR DESCRIPTION
This PR introduces and integrates the following `newtype` wrappers: `Felt`, `StackIndex` and `MemoryIndex`. It also fixes a number of bugs (see comments below) related to handling of integral types, for which this PR introduces the `newtype` wrappers.