### PR TITLE
Remove type-based name resolution from the AST 

### DIFF
--- a/src/Nightfall/Lang/Internal/Types.hs
+++ b/src/Nightfall/Lang/Internal/Types.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
 module Nightfall.Lang.Internal.Types
     ( module Nightfall.Lang.Internal.Types
     , Felt
@@ -51,15 +45,6 @@ data VarType =
     | VarBool
     | VarArrayOfFelt Word32  -- The argument is the length of the array.
     deriving (Eq, Show)
-
-ppVarType :: VarType -> String
-ppVarType VarFelt              = "felt"
-ppVarType VarBool              = "bool"
-ppVarType (VarArrayOfFelt len) = "[felt; " ++ show len ++ "]"
-
-isArrayOfFelt :: VarType -> Bool
-isArrayOfFelt VarArrayOfFelt{} = True
-isArrayOfFelt _                = False
 
 -- | Unary operations.
 data UnOp =
@@ -136,6 +121,15 @@ data Statement_ =
     -- | Allow to add empty lines in the generated code, for clarity
     | EmptyLine
     deriving (Eq, Show)
+
+ppVarType :: VarType -> String
+ppVarType VarFelt              = "felt"
+ppVarType VarBool              = "bool"
+ppVarType (VarArrayOfFelt len) = "[felt; " ++ show len ++ "]"
+
+isArrayOfFelt :: VarType -> Bool
+isArrayOfFelt VarArrayOfFelt{} = True
+isArrayOfFelt _                = False
 
 -- | What Miden considers to be a Word.
 data MidenWord = MidenWord

--- a/src/Nightfall/Lang/Syntax/DotRecord.hs
+++ b/src/Nightfall/Lang/Syntax/DotRecord.hs
@@ -101,16 +101,16 @@ boolean one:
 
     declareSetGetBool :: Body ()
     declareSetGetBool = do
-        Bool <- declare.x $ bool True
-        set.x $ bool False
+        Bool <- declare.x $ lit True
+        set.x $ lit False
         ret get.x
 
 or instead of a single-letter name use something more appropriate for serious production:
 
     declareSetGetProductionBool :: Body ()
     declareSetGetProductionBool = do
-        Bool <- declare.suchEnterpriseNameWowMuchDescriptive $ bool True
-        set.suchEnterpriseNameWowMuchDescriptive $ bool False
+        Bool <- declare.suchEnterpriseNameWowMuchDescriptive $ lit True
+        set.suchEnterpriseNameWowMuchDescriptive $ lit False
         ret get.suchEnterpriseNameWowMuchDescriptive
 
 If you attempt to declare the same variable twice, you'll get a Haskell type error:
@@ -130,7 +130,7 @@ error:
     declareFeltBool = do
         -- error: [GHC-18872]
         --     • Couldn't match type ‘DeclBool’ with ‘DeclFelt’
-        Felt <- declare.x $ bool True
+        Felt <- declare.x $ lit True
         pure ()
 
 If you attempt to use an undeclared variable, you'll get a Haskell type error too, although not a

--- a/src/Nightfall/Lang/Syntax/DotRecord.hs
+++ b/src/Nightfall/Lang/Syntax/DotRecord.hs
@@ -92,7 +92,7 @@ Here's how this program elaborates:
     >>> traverse_ print $ runBody declareSetGetFelt
     DeclVariable "x" (Lit (42 `modulo` 18446744069414584321))
     AssignVar "x" (Lit (3 `modulo` 18446744069414584321))
-    Return (VarF "x")
+    Return (Var "x")
 
 As you can see the @x@ name that we introduced via @declare@ became the @"x"@ name in the code.
 

--- a/src/Nightfall/Lang/Syntax/DotRecord.hs
+++ b/src/Nightfall/Lang/Syntax/DotRecord.hs
@@ -26,10 +26,11 @@ module Nightfall.Lang.Syntax.DotRecord where
 import Nightfall.Lang.Types
 import Nightfall.Lang.Internal.Types
 
-import GHC.TypeLits
-import GHC.Records
-import GHC.Exts
 import Data.Kind
+import Data.Proxy
+import GHC.Exts
+import GHC.Records
+import GHC.TypeLits
 import Unsafe.Coerce (UnsafeEquality (..), unsafeEqualityProof)
 
 {- Note [Surface syntax through OverloadedRecordDot]
@@ -198,16 +199,19 @@ data DeclTypeOf name a where
 type KnownDecl :: (Symbol -> Type) -> Type -> Constraint
 class KnownDecl decl a | decl -> a, a -> decl where
     knownDecl :: forall name. TypeOf name ~ a => decl name
+    varType :: Proxy a -> VarType
 
 data DeclFelt name where
     Felt :: TypeOf name ~ Felt => DeclFelt name
 instance KnownDecl DeclFelt Felt where
     knownDecl = Felt
+    varType _ = VarFelt
 
 data DeclBool name where
     Bool :: TypeOf name ~ Bool => DeclBool name
 instance KnownDecl DeclBool Bool where
     knownDecl = Bool
+    varType _ = VarBool
 
 class KnownType a where
     knownType :: forall name. TypeOf name ~ a => DeclTypeOf name a
@@ -246,7 +250,7 @@ instance
         ) => HasField name (Prefix "declare" a) res where
     getField _ (Expr expr_) = do
         let name = symbolVal' (proxy# @name)
-        statement $ DeclVariable name expr_
+        statement $ DeclVariable (varType $ Proxy @a) name expr_
         -- It would be very dangerous to allow for forging multiple @TypeOf name ~ a1@,
         -- @TypeOf name ~ a2@ etc constraints, since GHC could conclude @a1 ~ a2@ from those,
         -- which for all intents and purposes would be implicit uncontrolled 'unsafeCoerce', but
@@ -257,11 +261,7 @@ instance
 
 instance (res ~ Expr a, TypeOf name ~ a, KnownSymbol name, KnownType a) =>
         HasField name (Prefix "get" a) res where
-    getField _ = Expr $ case knownType @a @name of
-        DeclFelt -> VarF name
-        DeclBool -> VarB name
-      where
-        name = symbolVal' (proxy# @name)
+    getField _ = Expr . Var $ symbolVal' (proxy# @name)
 
 -- 'KnownType' is only needed to prevent @set.x@ from being successfully type checked when there's
 -- no @x@ in the current scope. Without the constraint, GHC would happily infer

--- a/src/Nightfall/Lang/Types.hs
+++ b/src/Nightfall/Lang/Types.hs
@@ -31,8 +31,6 @@ module Nightfall.Lang.Types ( Felt
                             , gt
                             , gte
                             , isOdd
-                            , varF
-                            , varB
                             , getAt
                             , setAt
                             , statement
@@ -181,13 +179,6 @@ gte (Expr e1) (Expr e2) = Expr $ BinOp GreaterEq e1 e2
 
 isOdd :: Expr Felt -> Expr Bool
 isOdd (Expr e) = Expr $ UnOp IsOdd e
-
--- ** Variables (typed)
-varF :: VarName -> Expr Felt
-varF = Expr . Var
-
-varB :: VarName -> Expr Bool
-varB = Expr . Var
 
 getAt :: VarName -> Expr Felt -> Expr Felt
 getAt var (Expr i) = Expr $ GetAt var i

--- a/src/Nightfall/Lang/Types.hs
+++ b/src/Nightfall/Lang/Types.hs
@@ -19,7 +19,6 @@ module Nightfall.Lang.Types ( Felt
                             , mkSimpleProgram
                             , mkZKProgram
                             , lit
-                            , bool
                             , add
                             , sub
                             , mul
@@ -65,20 +64,23 @@ newtype Expr a = Expr
     } deriving (Eq, Show)
 
 class IsBuiltin a where
-    mkConstant :: a -> Constant
+    literal :: a -> Literal
 
 instance IsBuiltin Felt where
-    mkConstant = ConstantFelt
+    literal = LiteralFelt
 
-constant :: IsBuiltin a => a -> Expr a
-constant = Expr . Constant . mkConstant
+instance IsBuiltin Bool where
+    literal = LiteralBool
+
+lit :: IsBuiltin a => a -> Expr a
+lit = Expr . Literal . literal
 
 -- | Num instance to make writings easier, to allow wriring expressions with "+", "-", etc.
 instance a ~ Felt => Num (Expr a) where
     (+) = add
     (-) = sub
     (*) = mul
-    fromInteger = constant . fromInteger
+    fromInteger = lit . fromInteger
     abs = error "'abs' not implemented for 'Expr'"
     signum = error "'signum' not implemented for 'Expr'"
 
@@ -139,15 +141,6 @@ mkZKProgram name body pubs secretFP = ZKProgram
 -- instead of constructing the types directly.
 
 -- ** Literals
-
-lit :: Felt -> Expr Felt
-lit = Expr . Lit
-
-bool :: Bool -> Expr Bool
-bool = Expr . Bo
-
-cast128to256 :: Expr (UInt 128) -> Expr (UInt 256)
-cast128to256 (Expr e) = Expr e
 
 -- ** Arithmetic operations
 

--- a/src/Nightfall/MASM.hs
+++ b/src/Nightfall/MASM.hs
@@ -65,14 +65,20 @@ ppInstr (While body) = do
   "while.true"
   indent $ traverse_ ppInstr body
   "end"
+ppInstr (Repeat count body) = do
+  [ "repeat." ++ show count ]
+  indent $ traverse_ ppInstr body
+  "end"
 
 ppInstr (LocStore n) = [ "loc_store." ++ show n ]
 ppInstr (LocLoad n) = [ "loc_load." ++ show n ]
 
 ppInstr (AdvPush n) = [ "adv_push." ++ show n ]
 ppInstr (Push ns) = [ "push" ++ concatMap (\n -> '.' : show n) ns ]
+ppInstr Padw = [ "padw" ]
 ppInstr (Swap n) = [ "swap" ++ if unStackIndex n == 1 then "" else "." ++ show n ]
 ppInstr Drop = "drop"
+ppInstr Dropw = "dropw"
 ppInstr CDrop = "cdrop"
 ppInstr (Dup n) = [ "dup." ++ show n ]
 ppInstr (MoveUp n) = [ "movup." ++ show n ]
@@ -122,7 +128,9 @@ ppInstr IRotr = "u32checked_rotr"
 ppInstr IPopcnt = "u32checked_popcnt"
 
 ppInstr (MemLoad mi) = [ "mem_load" ++ maybe "" (\i -> "." ++ show i) mi ]
+ppInstr (MemLoadw mi) = [ "mem_loadw" ++ maybe "" (\i -> "." ++ show i) mi ]
 ppInstr (MemStore mi) = [ "mem_store" ++ maybe "" (\i -> "." ++ show i) mi ]
+ppInstr (MemStorew mi) = [ "mem_storew" ++ maybe "" (\i -> "." ++ show i) mi ]
 ppInstr IAdd64 = "exec.u64::wrapping_add"
 ppInstr ISub64 = "exec.u64::wrapping_sub"
 ppInstr IMul64 = "exec.u64::wrapping_mul"

--- a/src/Nightfall/MASM/Types.hs
+++ b/src/Nightfall/MASM/Types.hs
@@ -23,14 +23,15 @@ import Nightfall.MASM.Integral
 import Nightfall.Lang.Types
 
 import Control.Monad.Writer.Strict
-import qualified Data.DList as DList
 import Data.Map.Strict (Map)
 import Data.String
 import Data.Text (Text)
 import Data.Typeable
 import Data.Word (Word32)
-import qualified GHC.Exts
 import GHC.Generics
+import GHC.Natural
+import qualified Data.DList as DList
+import qualified GHC.Exts
 
 type ProcName = Text
 
@@ -65,10 +66,13 @@ data Instruction
         elseBranch :: [Instruction]
       }
   | While [Instruction] -- while.true
+  | Repeat Natural [Instruction] -- repeat.count
   | AdvPush (StackIndex 1 16)  -- adv_push.n
   | Push [Felt] -- push.a.b.c
+  | Padw -- padw
   | Swap (StackIndex 1 15) -- swap[.i]
   | Drop -- drop
+  | Dropw -- dropw
   | CDrop -- cdrop
   | Dup (StackIndex 0 15) -- dup.n
   | MoveUp (StackIndex 2 15) -- movup.n
@@ -86,7 +90,9 @@ data Instruction
   | LocStore MemoryIndex -- loc_store.i
   | LocLoad MemoryIndex -- loc_load.i
   | MemLoad (Maybe MemoryIndex) -- mem_load[.i]
+  | MemLoadw (Maybe MemoryIndex) -- mem_loadw[.i]
   | MemStore (Maybe MemoryIndex) -- mem_store[.i]
+  | MemStorew (Maybe MemoryIndex) -- mem_storew[.i]
   | Add (Maybe Felt) -- add[.n]
   | Sub (Maybe Felt) -- sub[.n]
   | Mul (Maybe Felt) -- mul[.n]

--- a/src/Nightfall/Targets/Miden.hs
+++ b/src/Nightfall/Targets/Miden.hs
@@ -282,9 +282,8 @@ transpileStatement EmptyLine = return . singleton $ MASM.EmptyL
 
 -- | Transpile an unary operation.
 transpileUnOp :: UnOp -> [Instruction]
-transpileUnOp NFTypes.Not          = [ MASM.Not   ]
-transpileUnOp NFTypes.IsOdd        = [ MASM.IsOdd ]
-transpileUnOp NFTypes.Cast128to256 = [ MASM.Padw  ]
+transpileUnOp NFTypes.Not   = [ MASM.Not   ]
+transpileUnOp NFTypes.IsOdd = [ MASM.IsOdd ]
 
 -- | Transpile a binary operation.
 transpileBinOp :: BinOp -> [Instruction]
@@ -300,16 +299,16 @@ transpileBinOp LowerEq        = [ MASM.Lte ]
 transpileBinOp Greater        = [ MASM.Gt ]
 transpileBinOp GreaterEq      = [ MASM.Gte ]
 
+transpileLiteral :: Literal -> State Context [Instruction]
+transpileLiteral (LiteralFelt x) = return . singleton $ Push [x]
+transpileLiteral (LiteralBool b) = return . singleton $ Push [if b then 1 else 0]
+
 -- TODO: range check, etc.
 transpileExpr :: Expr_ -> State Context [Instruction]
 -- transpileExpr (Lit _) = error "Can't transpile standalone literal" -- should be simply push it to the stack??
 -- transpileExpr (Bo _)  = error "Can't transpile standalone boolean"
 -- | Literals are simply pushed onto the stack
-transpileExpr (Lit felt) = do
-    return . singleton $ Push [felt]
-transpileExpr (Bo bo) = do
-    let felt = if bo then 1 else 0
-    return . singleton $ Push [felt]
+transpileExpr (Literal l) = transpileLiteral l
 
 transpileExpr (Var varname) = do
     -- Fetch the memory location of that variable in memory, and push it to the stack

--- a/src/Nightfall/Targets/Miden.hs
+++ b/src/Nightfall/Targets/Miden.hs
@@ -6,6 +6,7 @@ module Nightfall.Targets.Miden ( Context(..)
                                , defaultContext
                                , Config(..)
                                , defaultConfig
+                               , VarInfo(..)
                                , toHashModule
                                , transpile
                                ) where
@@ -15,18 +16,20 @@ import Nightfall.Lang.Types
 import Nightfall.MASM.Types as MASM
 import Nightfall.MASM.Miden
 
+import Control.Monad
 import Control.Monad.State
 import Data.Coerce (coerce)
+import Data.Foldable
 import Data.List (genericLength, singleton)
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
 import Data.Monoid
 import Data.Set (Set)
+import Data.Word
+import System.IO.Unsafe
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as SText
 import qualified Data.Text as Strict (Text)
-import Data.Word
-import System.IO.Unsafe
 
 -- | Applicatively fold a 'Foldable'.
 foldMapA
@@ -48,12 +51,17 @@ defaultConfig = Config
     , cfgTraceVariablesUsage = False
 }
 
+data VarInfo = VarInfo
+    { _varInfoType :: VarType
+    , _varInfoPos  :: MemoryIndex
+    }
+
 -- TODO: a Note about 'adviceMapExt' and 'importExt'.
 -- | Context for the transpilation, this is the state of the State Monad in which transpilation happens
 data Context = Context
     { progName :: String                   -- ^ Name of the program, for outputs logs, etc.
     , memPos :: MemoryIndex                -- ^ Next free indice in Miden's global memory
-    , variables :: Map String MemoryIndex  -- ^ Variables in the EDSL are stored in Miden's random
+    , variables :: Map String VarInfo      -- ^ Variables in the EDSL are stored in Miden's random
                                              -- access memory, we keep a map to match them
     , adviceMapExt :: Map Strict.Text [MidenWord]  -- ^ Entries to add to the inputs file
     , importExt :: Set Strict.Text         -- ^ Imports to add to the final program
@@ -97,23 +105,30 @@ getHash numWords midenWords =
     -- TODO: should transpilation work in IO instead or can we treat 'runMiden' as "morally-pure"?
     fmap reverse . unsafePerformIO $ runMiden DontKeep (Just 4) $ toHashModule numWords midenWords
 
+toNumWords :: VarType -> Word32
+toNumWords VarFelt              = 1
+toNumWords VarBool              = 1
+toNumWords (VarArrayOfFelt len) = len
+
 -- | Allocate memory for a variable.
 alloc
     :: VarName
-    -> Word32  -- ^ How many Miden words to allocate.
+    -> VarType
     -> State Context MemoryIndex
-alloc var numWords = do
-    varPos <- gets memPos
+alloc var varType = do
     vars <- gets variables
     if Map.member var vars
         then error $ "Variable '" ++ var ++ "' has already been declared!"
-        else modify $ \ctx -> ctx
-            { memPos = case toMemoryIndex $ unMemoryIndex varPos + fromIntegral numWords of
-                Nothing      -> error "Out of Miden's memory"
-                Just memPos' -> memPos'
-            , variables = Map.insert var varPos vars
-            }
-    pure varPos
+        else do
+            varPos <- gets memPos
+            let numWords = toNumWords varType
+            modify $ \ctx -> ctx
+                { memPos = case toMemoryIndex $ unMemoryIndex varPos + fromIntegral numWords of
+                    Nothing      -> error "Out of Miden's memory"
+                    Just memPos' -> memPos'
+                , variables = Map.insert var (VarInfo varType varPos) vars
+                }
+            pure varPos
 
 -- | Entry point: transpile a EDSL-described ZK program into a Miden Module
 transpile :: ZKProgram -> State Context Module
@@ -152,15 +167,18 @@ transpileStatement (IfElse cond ifBlock elseBlock) = do
     -- I'm supposing it takes a pop/drop operation + a comparison
     cond' <- transpileExpr cond
     return $ cond' <> [ MASM.If ifBlock' elseBlock' ]
+transpileStatement (NFTypes.Repeat count body) = do
+    body' <- foldMapA transpileStatement body
+    return $ [ MASM.Repeat count body' ]
 transpileStatement (NFTypes.While cond body) = do
     body' <- foldMapA transpileStatement body
     cond' <- transpileExpr cond
     return $ cond' <> [ MASM.While $ body' <> cond' ]
 
 -- | Declaring a variable loads the expression into Miden's global memory, and we track the index in memory
-transpileStatement (DeclVariable var e) = do
+transpileStatement (DeclVariable varType var e) = do
     cfg <- gets config
-    varPos <- alloc var 1
+    varPos <- alloc var varType
     -- Trace the variable declaration if configured
     let traceVar = [MASM.Comment $ "var " <> SText.pack var | cgfTraceVariablesDecl cfg]
     -- Transpile the variable value
@@ -179,18 +197,20 @@ transpileStatement (AssignVar var e) = do
             , var
             , "\" has not been declared before: can't assign value"
             ]
-        Just pos -> do
+        Just varInfo -> do
             -- Trace the variable usage if configured
             let traceVar = [MASM.Comment $ "var " <> SText.pack var | shouldTrace]
             e' <- transpileExpr e
-            return $ e' <> traceVar <> [ MASM.MemStore . Just $ pos ]
+            return $ e' <> traceVar <> [ MASM.MemStore . Just $ _varInfoPos varInfo ]
 
 transpileStatement (SetAt arr i val) = do
     vars <- gets variables
-    -- TODO: also check that @arr@ is an array.
-    case unMemoryIndex <$> Map.lookup arr vars of
+    case Map.lookup arr vars of
         Nothing -> error $ "variable \"" ++ arr ++ "\" unknown (undeclared)"
-        Just arrPos -> do
+        Just varInfo -> do
+            unless (isArrayOfFelt $ _varInfoType varInfo) $
+                error $ "'" ++ arr ++ "' is used as an array, but it's not one"
+            let arrPos = unMemoryIndex $ _varInfoPos varInfo
             shouldTrace <- gets (cfgTraceVariablesUsage . config)
             let traceVar =
                     [ MASM.Comment $ "an element of '" <> SText.pack arr <> "' number"
@@ -218,7 +238,7 @@ transpileStatement (NakedCall fname args) = do
 transpileStatement (InitArray arr inputs) = do
     let numWords = genericLength inputs
         inputsAsWords = padListAsWords inputs
-    arrPos <- alloc arr numWords
+    arrPos <- alloc arr $ VarArrayOfFelt numWords
     let hash = either error id $ getHash numWords inputsAsWords
     -- TODO: use @lens@ already.
     modify $ \ctx -> ctx
@@ -262,8 +282,9 @@ transpileStatement EmptyLine = return . singleton $ MASM.EmptyL
 
 -- | Transpile an unary operation.
 transpileUnOp :: UnOp -> [Instruction]
-transpileUnOp NFTypes.Not   = [ MASM.Not   ]
-transpileUnOp NFTypes.IsOdd = [ MASM.IsOdd ]
+transpileUnOp NFTypes.Not          = [ MASM.Not   ]
+transpileUnOp NFTypes.IsOdd        = [ MASM.IsOdd ]
+transpileUnOp NFTypes.Cast128to256 = [ MASM.Padw  ]
 
 -- | Transpile a binary operation.
 transpileBinOp :: BinOp -> [Instruction]
@@ -290,34 +311,28 @@ transpileExpr (Bo bo) = do
     let felt = if bo then 1 else 0
     return . singleton $ Push [felt]
 
--- Using a variable means we fetch the value from (global) memory and push it to the stack
-transpileExpr (VarF varname) = do
+transpileExpr (Var varname) = do
     -- Fetch the memory location of that variable in memory, and push it to the stack
     vars <- gets variables
     case Map.lookup varname vars of
-        Nothing -> error $ "Felt variable \"" ++ varname ++ "\" unknown (undeclared)"
-        Just idx -> do
+        Nothing -> error $ "variable '" ++ varname ++ "' unknown (undeclared)"
+        Just varInfo -> do
             shouldTrace <- gets (cfgTraceVariablesUsage . config)
             let traceVar =
-                    [MASM.Comment $ "var " <> SText.pack varname <> " (felt)" | shouldTrace]
-            return $ traceVar <> [MemLoad . Just $ idx]
-transpileExpr (VarB varname) = do
-    -- Fetch the memory location of that variable in memory, and push it to the stack
-    vars <- gets variables
-    case Map.lookup varname vars of
-        Nothing -> error $ "Boolean variable \"" ++ varname ++ "\" unknown (undeclared)"
-        Just idx -> do
-            shouldTrace <- gets (cfgTraceVariablesUsage . config)
-            let traceVar =
-                    [MASM.Comment $ "var " <> SText.pack varname <> " (bool)" | shouldTrace]
-            return $ traceVar <> [MemLoad . Just $ idx]
+                    [ MASM.Comment . SText.pack $ fold
+                        ["var ", varname, " (", ppVarType $ _varInfoType varInfo, ")"]
+                    | shouldTrace
+                    ]
+            return $ traceVar <> [MemLoad . Just $ _varInfoPos varInfo]
 
 transpileExpr (GetAt arr i) = do
     vars <- gets variables
-    -- TODO: also check that @arr@ is an array.
-    case unMemoryIndex <$> Map.lookup arr vars of
+    case Map.lookup arr vars of
         Nothing -> error $ "Array variable \"" ++ arr ++ "\" unknown (undeclared)"
-        Just arrPos -> do
+        Just varInfo -> do
+            unless (isArrayOfFelt $ _varInfoType varInfo) $
+                error $ "'" ++ arr ++ "' is used as an array, but it's not one"
+            let arrPos = unMemoryIndex $ _varInfoPos varInfo
             shouldTrace <- gets (cfgTraceVariablesUsage . config)
             let traceVar =
                     [ MASM.Comment $ "an element of '" <> SText.pack arr <> "' number"


### PR DESCRIPTION
The main purpose of this PR is to replace `VarF` and `VarB` with a single constructor `Var` and move the type information to `DeclVariable` like it's usually done in programming languages.

The PR also does some other things, see below.